### PR TITLE
remove duplicate UploadMeshData calls on the same mesh

### DIFF
--- a/03_challenge_maze3d/lessons/04_maze_game_models.c
+++ b/03_challenge_maze3d/lessons/04_maze_game_models.c
@@ -1149,9 +1149,6 @@ static Mesh LoadOBJ(const char *fileName)
     // NOTE: At this point we have all vertex, texcoord, normal data for the model in mesh struct
     TraceLog(LOG_INFO, "[%s] Mesh loaded successfully in RAM (CPU)", fileName);
     
-    // Upload mesh data into VRAM
-    UploadMeshData(&mesh);
-
     return mesh;
 }
 

--- a/03_challenge_maze3d/lessons/05_maze_game_cubicmap.c
+++ b/03_challenge_maze3d/lessons/05_maze_game_cubicmap.c
@@ -1161,9 +1161,6 @@ static Mesh LoadOBJ(const char *fileName)
     // NOTE: At this point we have all vertex, texcoord, normal data for the model in mesh struct
     TraceLog(LOG_INFO, "[%s] Mesh loaded successfully in RAM (CPU)", fileName);
     
-    // Upload mesh data into VRAM
-    UploadMeshData(&mesh);
-
     return mesh;
 }
 

--- a/03_challenge_maze3d/lessons/06_maze_game_camera.c
+++ b/03_challenge_maze3d/lessons/06_maze_game_camera.c
@@ -1182,9 +1182,6 @@ static Mesh LoadOBJ(const char *fileName)
     // NOTE: At this point we have all vertex, texcoord, normal data for the model in mesh struct
     TraceLog(LOG_INFO, "[%s] Mesh loaded successfully in RAM (CPU)", fileName);
     
-    // Upload mesh data into VRAM
-    UploadMeshData(&mesh);
-
     return mesh;
 }
 

--- a/03_challenge_maze3d/lessons/07_maze_game_collisions.c
+++ b/03_challenge_maze3d/lessons/07_maze_game_collisions.c
@@ -1228,9 +1228,6 @@ static Mesh LoadOBJ(const char *fileName)
     // NOTE: At this point we have all vertex, texcoord, normal data for the model in mesh struct
     TraceLog(LOG_INFO, "[%s] Mesh loaded successfully in RAM (CPU)", fileName);
     
-    // Upload mesh data into VRAM
-    UploadMeshData(&mesh);
-
     return mesh;
 }
 


### PR DESCRIPTION
good morning. In all changed files, after LoadOBJ() is called, UploadMeshData() is called on the returned mesh:
``` c
    // LESSON 04: Load 3d model
    Mesh mesh = LoadOBJ("resources/dwarf.obj");     // Load mesh data from OBJ file
    UploadMeshData(&mesh);                          // Upload mesh data to GPU memory (VRAM)
```
but UploadMeshData() is also called inside the LoadOBJ() function right before return statement:
``` c
    // Upload mesh data into VRAM
    UploadMeshData(&mesh);

    return mesh;
```
so UploadMeshData() is unnecessary in LoadOBJ() function. or vice versa, we should keep UploadMeshData() in LoadOBJ() and remove the others.